### PR TITLE
[Fix] Fix fake data generating

### DIFF
--- a/src/sockets/productsChannel.js
+++ b/src/sockets/productsChannel.js
@@ -8,15 +8,15 @@ export default function productsChannel(io) {
     .on('connection', function(socket) {
       console.log('A client is connected.')
   
-      const jsonDataGenerator = new JsonDataGenerator()
-  
-      setInterval(() => {
-        const jsonString = jsonDataGenerator.generate(NUMBER_OF_GENERATED_PRODUCTS_PER_INTERVAL)
-        products.emit('products', { data: JSON.parse(jsonString) })
-      }, DELAY_FOR_PRODUCTS_GENERATING)
-  
       socket.on('disconnect', function () {
         console.log('A client is disconnected.')
       })
     })
+
+  const jsonDataGenerator = new JsonDataGenerator()
+
+  setInterval(() => {
+    const jsonString = jsonDataGenerator.generate(NUMBER_OF_GENERATED_PRODUCTS_PER_INTERVAL)
+    products.emit('products', { data: JSON.parse(jsonString) })
+  }, DELAY_FOR_PRODUCTS_GENERATING)
 }


### PR DESCRIPTION
When a new client connects to the socket - a new setInterval callback is added to the macro tasks queue, so we have the increased crazy data generating with each new client connection. Solution: move the logic for data generating independently from the connection handler.